### PR TITLE
fix(map): let the LLM inject the map in the text response (refs #60)

### DIFF
--- a/app/helpers/gradio.py
+++ b/app/helpers/gradio.py
@@ -1,16 +1,47 @@
 import json
 import logging
 import re
+
 import gradio as gr
 
 logger = logging.getLogger(__name__)
 
-# TODO: This is a very hacky way to remove map HTML from assistant messages.
-# We should ideally have a better way to separate map content from text content in the message structure.
-_MAP_TAG_RE = re.compile(
-    r"<ol-simple-map\b[^>]*>(?:\s*</ol-simple-map>)?",
-    flags=re.IGNORECASE | re.DOTALL,
+# ``create_map`` map markup: the Chatbot escapes ``<ol-simple-map>`` in Markdown,
+# so we extract the block and render it with ``gr.HTML``.
+_OL_SIMPLE_MAP_BLOCK = re.compile(
+    r"<ol-simple-map\b[^>]*/>|<ol-simple-map\b[^>]*>[\s\S]*?</ol-simple-map>",
+    flags=re.IGNORECASE,
 )
+
+
+def _ai_content_for_gradio_chatbot(text: str) -> str | list:
+    """Split assistant markdown so ``<ol-simple-map>`` is not escaped.
+
+    The Chatbot renders strings as Markdown, so custom map tags show as literal
+    text. Each match from ``_OL_SIMPLE_MAP_BLOCK`` becomes ``gr.HTML(block)``;
+    other segments stay plain strings (unchanged Markdown). Returns ``text`` if
+    there is nothing to split or the regex matches nothing; otherwise a single
+    ``gr.HTML`` or a list alternating strings and ``gr.HTML`` in message order.
+    """
+    if "<ol-simple-map" not in text.casefold():
+        return text
+    matches = list(_OL_SIMPLE_MAP_BLOCK.finditer(text))
+    if not matches:
+        return text
+    chunks: list = []
+    last_end = 0
+    for m in matches:
+        before = text[last_end : m.start()]
+        if before:
+            chunks.append(before)
+        chunks.append(gr.HTML(m.group(0)))
+        last_end = m.end()
+    after = text[last_end:]
+    if after:
+        chunks.append(after)
+    if len(chunks) == 1:
+        return chunks[0]
+    return chunks
 
 
 def to_gradio_message(message):
@@ -22,18 +53,18 @@ def to_gradio_message(message):
         logger.warning(f"last_message: {message.pretty_print()}")
         return None
 
-    # Extraire le contenu textuel
+    # Extract textual content
     text_content = ""
     if isinstance(message.content, str):
         text_content = message.content
     elif isinstance(message.content, list):
-        # Extraire le texte des blocks de contenu
+        # Extract text from content blocks
         text_parts = []
         for block in message.content:
             if isinstance(block, dict) and block.get("type") == "text":
                 text_parts.append(block.get("text", ""))
             elif isinstance(block, dict) and block.get("type") == "tool_use":
-                # Afficher les appels d'outils de manière lisible
+                # Show tool calls in a readable form
                 tool_name = block.get("name", "unknown")
                 tool_args = block.get("input", {})
                 text_parts.append(f"🔧 Appel outil: {tool_name}({tool_args})")
@@ -43,34 +74,27 @@ def to_gradio_message(message):
         logger.warning(f"message: {message.pretty_print()}")
         return None
 
-    # Ajouter un nouveau message pour chaque type d'événement
+    # One chat bubble per LangChain message type
     if message.type == "human":
         return {
             "role": "user",
             "content": f"{text_content}",
         }
     elif message.type == "ai":
-        # TODO : A dirty hack for now to avoid showing raw map HTML in assistant text. 
-        # We should ideally have a better way to separate map content from text content in the message structure.
-        cleaned_text = _MAP_TAG_RE.sub("", text_content).strip()
-        if cleaned_text == "":
+        text_stripped = text_content.strip()
+        if text_stripped == "":
             return None
         return {
             "role": "assistant",
-            "content": f"{cleaned_text}",
-            # "metadata": {"title": "💭 Réflexion"}
+            "content": _ai_content_for_gradio_chatbot(text_stripped),
         }
     elif message.type == "tool":
-        # Si c'est une carte, l'afficher dans un bloc dédié
+        # Map tool: no separate bubble — the LLM pastes the fragment into the next reply.
         if "<ol-simple-map" in text_content:
-            return {
-                "role": "assistant",
-                "content": gr.HTML(text_content),
-                "metadata": {"title": "🗺️ Carte"},
-            }
+            return None
 
         tool_title = "📊 Résultat outil"
-        # Si c'est du JSON valide, le formater avec coloration syntaxique
+        # Pretty-print valid JSON for syntax highlighting in the UI
         try:
             parsed_json = json.loads(text_content)
             formatted_json = json.dumps(parsed_json, indent=2, ensure_ascii=False)
@@ -96,7 +120,7 @@ def to_gradio_message(message):
                 "metadata": {"title": tool_title},
             }
     else:
-        # Autres types de nœuds
+        # Other LangGraph / LangChain node types
         return {
             "role": "assistant",
             "content": f"[{message.type}] {text_content}",

--- a/app/tools.py
+++ b/app/tools.py
@@ -5,7 +5,14 @@ def create_map(
     lon: float = None, lat: float = None, zoom: int = None,
     geojson_url: str = "", background: str = "osm"
 ) -> str:
-    """Crée une carte et la renvoie sous forme de chaîne HTML.
+    """Crée une carte et la renvoie sous forme d'un seul fragment HTML.
+
+    La valeur de retour est une balise ``<ol-simple-map ...></ol-simple-map>`` à
+    recopier **à l'identique** (mêmes attributs, même ordre) dans la prochaine
+    réponse assistant en markdown, à l'endroit où la carte doit apparaître
+    (par ex. après une phrase d'introduction, puis le texte explicatif peut
+    suivre). Sans ce fragment dans cette réponse, la carte ne s'affiche pas
+    dans le chat.
 
     Paramètres :
         lon : longitude du centre (optionnelle si `geojson_url` est fourni)

--- a/tests/test_helpers_gradio.py
+++ b/tests/test_helpers_gradio.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import gradio as gr
+
 from app.helpers.gradio import to_gradio_message
 
 
@@ -30,16 +32,32 @@ def test_to_gradio_message_ai_string() -> None:
     assert out == {"role": "assistant", "content": "Hi there"}
 
 
-def test_to_gradio_message_ai_only_map_markup_returns_none() -> None:
+def test_to_gradio_message_ai_only_map_markup_uses_gr_html() -> None:
     text = '<ol-simple-map lon="3.28274" lat="47.368178"></ol-simple-map>'
     out = to_gradio_message(_message("ai", text))
-    assert out is None
+    assert out["role"] == "assistant"
+    assert isinstance(out["content"], gr.HTML)
 
 
-def test_to_gradio_message_ai_text_with_map_markup_keeps_text() -> None:
+def test_to_gradio_message_ai_text_with_map_splits_markdown_and_html() -> None:
     text = "Voici la carte:\n<ol-simple-map lon=\"3.28274\" lat=\"47.368178\"></ol-simple-map>"
     out = to_gradio_message(_message("ai", text))
-    assert out == {"role": "assistant", "content": "Voici la carte:"}
+    assert out["role"] == "assistant"
+    parts = out["content"]
+    assert isinstance(parts, list)
+    assert parts[0] == "Voici la carte:\n"
+    assert isinstance(parts[1], gr.HTML)
+
+
+def test_to_gradio_message_ai_text_map_then_text_trailing() -> None:
+    text = (
+        "Avant\n<ol-simple-map lon=\"1\" lat=\"2\"></ol-simple-map>\nAprès"
+    )
+    out = to_gradio_message(_message("ai", text))
+    parts = out["content"]
+    assert parts[0] == "Avant\n"
+    assert isinstance(parts[1], gr.HTML)
+    assert parts[2] == "\nAprès"
 
 
 def test_to_gradio_message_list_text_and_tool_use() -> None:
@@ -73,10 +91,9 @@ def test_to_gradio_message_tool_non_json_plain() -> None:
     }
 
 
-def test_to_gradio_message_tool_map_title_when_ol_tag() -> None:
+def test_to_gradio_message_tool_map_suppressed_for_llm_injection() -> None:
     text = json.dumps({"html": "<ol-simple-map />"})
-    out = to_gradio_message(_message("tool", text))
-    assert out["metadata"]["title"] == "🗺️ Carte"
+    assert to_gradio_message(_message("tool", text)) is None
 
 
 def test_to_gradio_message_unknown_node_type() -> None:


### PR DESCRIPTION
(closes #60)

## Changes

- Stop displaying HTML for the map in tool response
- Split AI message to interpret HTML code for the map (`str` -> `list[str|gr.HTML]`) : 

```py
def test_to_gradio_message_ai_text_map_then_text_trailing() -> None:
    text = (
        "Avant\n<ol-simple-map lon=\"1\" lat=\"2\"></ol-simple-map>\nAprès"
    )
    out = to_gradio_message(_message("ai", text))
    parts = out["content"]
    assert parts[0] == "Avant\n"
    assert isinstance(parts[1], gr.HTML)
    assert parts[2] == "\nAprès"
```


## Result

> Affiche la commune de Menou sur une carte

<img width="1171" height="551" alt="image" src="https://github.com/user-attachments/assets/eebfb047-4e8e-4275-b122-e961c0d19006" />

