### PR TITLE
Export tool for conversation threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ export GOOGLE_API_KEY="YourApiKey"
 docker compose up -d
 ```
 
+## Advanced usage
+
+### Export history and token consuption
+
+```bash
+# Use the following command to generate a CSV file
+uv run python -m app.export
+```
+
+
 ## Credits
 
 * [gradio - Chatbot](https://www.gradio.app/docs/gradio/chatbot)

--- a/app/export.py
+++ b/app/export.py
@@ -1,0 +1,55 @@
+import asyncio
+
+import csv
+import sys
+from .services.db import get_database, get_thread_ids
+from .services.agent import get_agent_no_tools, get_messages
+
+
+async def export_messages():
+    writer = csv.writer(sys.stdout)
+    writer.writerow([
+        'THREAD_ID',
+        'MESSAGE_COUNT',
+        'MESSAGE_DATE',
+        'MESSAGE_TYPE',
+        'INPUT_TOKENS',
+        'OUTPUT_TOKENS',
+        'TOTAL_TOKENS',
+        'MESSAGE_CONTENT'
+    ])
+
+    async with get_database() as db:
+        thread_ids = await get_thread_ids(db)
+    
+        async with get_agent_no_tools() as agent:
+            for thread_id in thread_ids:
+                message_count = 0
+                async for message, message_date in get_messages(agent, thread_id):
+                    message_count += 1
+                    if hasattr(message,'usage_metadata'):
+                        input_token = message.usage_metadata['input_tokens']
+                        output_tokens = message.usage_metadata['output_tokens']
+                        total_tokens = message.usage_metadata['total_tokens']
+                    else:
+                        input_token = 0
+                        output_tokens = 0
+                        total_tokens = 0
+                        
+                    message_content="NA"
+                    if message.type == "human":
+                        message_content =  message.text
+                        
+                    writer.writerow([
+                        thread_id,
+                        message_count,
+                        message_date,
+                        message.type,
+                        input_token,
+                        output_tokens,
+                        total_tokens,
+                        message_content
+                    ])
+
+if __name__ == '__main__':
+    asyncio.run(export_messages())

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -70,12 +70,36 @@ async def get_agent() -> AsyncIterator[CompiledStateGraph]:
         yield agent
 
 
-async def get_messages(graph: CompiledStateGraph, thread_id: str) -> AsyncIterator[Any]:
-    """Itère sur l'historique des messages d'un thread."""
-    config = {"configurable": {"thread_id": thread_id}}
-    state = await graph.aget_state(config)
+@asynccontextmanager
+async def get_agent_no_tools() -> AsyncIterator[CompiledStateGraph]:
+    """Get an agent without tools to read the history of a thread"""
+    async with get_database() as db:
+        check_api_key()
+        logger.info("Create chat model: %s (temperature=%s)", MODEL_NAME, TEMPERATURE)
+        model = init_chat_model(MODEL_NAME, temperature=TEMPERATURE)
+        agent = create_agent(
+            model=model,
+            tools=[],
+            checkpointer=db.checkpointer,
+            middleware=[
+                ToolRetryMiddleware(
+                    max_retries=0,
+                    retry_on=(ToolException,),
+                    on_failure=format_tool_error,
+                )
+            ],
+        )
+        logger.info(f"Agent created successfully")
+        yield agent
 
-    if "messages" in state.values:
-        messages = state.values["messages"]
+
+
+async def get_messages(agent: CompiledStateGraph, thread_id: str) -> AsyncIterator[Any]:
+    """Get the history of a thread"""
+
+    config = {"configurable": {"thread_id": thread_id}}
+    state = await agent.aget_state(config)
+    if 'messages' in state.values:
+        messages = state.values['messages']
         for message in messages:
-            yield message
+            yield message,state.created_at

--- a/app/services/db.py
+++ b/app/services/db.py
@@ -78,13 +78,13 @@ async def is_database_healthy() -> bool:
         return await db.is_healthy()
 
 
-async def get_thread_ids(checkpointer: AsyncPostgresSaver) -> list[str]:
+async def get_thread_ids(database: BaseDatabase) -> list[str]:
     """Find thread_ids by inspecting checkpointer"""
     thread_ids = []
 
     try:
         logger.info("get_thread_ids(checkpointer) ...")
-        async for checkpoint_tuple in checkpointer.alist({}):
+        async for checkpoint_tuple in database.checkpointer.alist({}):
             config = checkpoint_tuple.config
             if "configurable" in config and "thread_id" in config["configurable"]:
                 thread_id = config["configurable"]["thread_id"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "uvicorn>=0.44.0",
     "langchain-mcp-adapters>=0.2.2",
 ]
+
 [dependency-groups]
 dev = [
   "langchain-ollama>=1.1.0",


### PR DESCRIPTION
Adds a small CLI (`app/export.py`) that dumps LangGraph checkpoint history to **CSV on stdout**: one row per message with thread id, sequence, timestamp, message type, token usage (when present), and human message text.

**Supporting changes**
- `get_thread_ids()` in `db.py` — discovers thread ids from the checkpointer.
- `get_agent_no_tools()` and `get_messages()` in `agent.py` — load thread state without MCP tools for read-only export.

 (closes #65)