### PR TITLE
Fix: Restore conversation history loading

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -82,8 +82,9 @@ async def load_conversation_history(thread_id: str):
     
     history = []
     try:
-        async for message in get_messages(graph, thread_id):
-            logger.debug(f"Traitement message: type={getattr(message, 'type', 'unknown')}, content={getattr(message, 'content', 'no content')}")
+        async for message, message_date in get_messages(graph, thread_id):
+
+            logger.debug(f"Traitement message: type={getattr(message, 'type', 'unknown')}, content={getattr(message, 'content', 'no content')}, date={message_date}")
             gradio_message = to_gradio_message(message)
             if gradio_message:
                 history.append(gradio_message)

--- a/tests/test_server_history.py
+++ b/tests/test_server_history.py
@@ -1,0 +1,49 @@
+"""Tests for app.server.load_conversation_history."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import app.server as server
+
+
+def test_load_conversation_history_returns_empty_when_graph_or_thread_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "graph", None)
+
+    assert asyncio.run(server.load_conversation_history("thread-1")) == []
+
+    monkeypatch.setattr(server, "graph", object())
+    assert asyncio.run(server.load_conversation_history("")) == []
+
+
+def test_load_conversation_history_accepts_tuple_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "graph", object())
+
+    human = SimpleNamespace(type="human", content="bonjour")
+    ai = SimpleNamespace(type="ai", content="salut")
+
+    async def fake_get_messages(_graph, _thread_id):
+        yield (human, "2026-01-01T00:00:00Z")
+        yield (ai, "2026-01-01T00:00:01Z")
+
+    def fake_to_gradio_message(message):
+        assert not isinstance(message, tuple)
+        return {"role": message.type, "content": message.content}
+
+    monkeypatch.setattr(server, "get_messages", fake_get_messages)
+    monkeypatch.setattr(server, "to_gradio_message", fake_to_gradio_message)
+
+    history = asyncio.run(server.load_conversation_history("thread-1"))
+
+    assert history == [
+        {"role": "human", "content": "bonjour"},
+        {"role": "ai", "content": "salut"},
+    ]
+


### PR DESCRIPTION
Fixes #68

The conversation history loading was broken after recent refactoring (refs #65). This PR restores the functionality by correctly awaiting the `get_messages` generator and adds tests to prevent regression.

### Changes

- Fix `load_conversation_history()` to properly iterate over async messages
- Add test for history loading functionality
